### PR TITLE
added gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # dependencies
-# node_modules/
+node_modules/
 .pnp
 .pnp.*
 .yarn/*
@@ -12,7 +12,7 @@
 coverage
 
 # next.js
-# .next/
+.next/
 out/
 
 # production
@@ -39,4 +39,4 @@ yarn-error.log*
 next-env.d.ts
 
 # turbo
-# .turbo/
+.turbo/

--- a/apps/iotricity/.gitignore
+++ b/apps/iotricity/.gitignore
@@ -1,0 +1,24 @@
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+/out
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.next/
+.turbo/
+.swc/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp.*
+.vscode/

--- a/apps/links/.gitignore
+++ b/apps/links/.gitignore
@@ -1,0 +1,24 @@
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+/out
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.next/
+.turbo/
+.swc/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp.*
+.vscode/

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,24 @@
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+/out
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.next/
+.turbo/
+.swc/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp.*
+.vscode/

--- a/packages/eslint-config/.gitignore
+++ b/packages/eslint-config/.gitignore
@@ -1,0 +1,22 @@
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+/out
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.swc/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp.*
+.vscode/

--- a/packages/typescript-config/.gitignore
+++ b/packages/typescript-config/.gitignore
@@ -1,0 +1,22 @@
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+/out
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.swc/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp.*
+.vscode/

--- a/packages/ui/.gitignore
+++ b/packages/ui/.gitignore
@@ -1,0 +1,22 @@
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+/out
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.swc/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp.*
+.vscode/


### PR DESCRIPTION
This pull request adds standardized `.gitignore` files across multiple application and package directories. The new `.gitignore` files help ensure that common dependencies, build outputs, environment files, and editor-specific files are not tracked by git, which keeps the repositories clean and avoids accidentally committing unnecessary or sensitive files.

The most important changes are:

**.gitignore standardization for applications:**
* Added comprehensive `.gitignore` files to `apps/iotricity`, `apps/links`, and `apps/web` to exclude dependencies (`node_modules`), build outputs, coverage reports, environment files, editor settings, and miscellaneous files from version control.

**.gitignore standardization for packages:**
* Added similar `.gitignore` files to `packages/eslint-config`, `packages/typescript-config`, and `packages/ui` to maintain consistency and prevent unwanted files from being committed in package directories.